### PR TITLE
Add test case for bootstrap with user args

### DIFF
--- a/ees_zoom/base_command.py
+++ b/ees_zoom/base_command.py
@@ -48,7 +48,7 @@ class BaseCommand:
         """
         log_level = self.config.get_value("log_level")
         logger = logging.getLogger(__name__)
-        logger.propagate = False
+        logger.propagate = True
         logger.setLevel(log_level)
 
         handler = logging.StreamHandler()

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -63,3 +63,20 @@ def test_execute(caplog):
     bootstrap_obj.workplace_search_client.create_content_source.assert_called_with(
         body=body
     )
+
+
+def test_execute_with_user_argument(caplog):
+    """Test execute method in Bootstrap file creates a content source using user argument in the Enterprise Search."""
+    args = argparse.Namespace()
+    args.name = "dummy"
+    args.user = "user1"
+    args.password = "user123"
+    args.config_file = CONFIG_FILE
+    caplog.set_level("INFO")
+    mock_response = {"id": "1234"}
+    bootstrap_obj = BootstrapCommand(args)
+    bootstrap_obj.workplace_search_client.create_content_source = Mock(
+        return_value=mock_response
+    )
+    bootstrap_obj.execute()
+    assert "Created ContentSource with ID 1234." in caplog.text


### PR DESCRIPTION
The goal of this PR is to address the following change:
 - Added a new test case for a bootstrap command when called with user args.