### PR TITLE
Handle 12702 error code under 400 status code

### DIFF
--- a/ees_zoom/zoom_past_meetings.py
+++ b/ees_zoom/zoom_past_meetings.py
@@ -57,6 +57,11 @@ class ZoomPastMeetings:
                 response = json.loads(past_meeting_response.text)
                 past_meeting_details = response
             elif past_meeting_response.status_code in [404, 400]:
+                response = json.loads(past_meeting_response.text)
+                self.logger.debug(
+                    f"Meeting with id {meeting_id} is skipped. "
+                    f"Error Code: {response['code']}, Reason: {response['message']}"
+                )
                 return None
             elif past_meeting_response.status_code == 401:
                 return self.get_past_meeting_details_from_meeting_id(

--- a/tests/test_zoom_past_meetings.py
+++ b/tests/test_zoom_past_meetings.py
@@ -317,8 +317,11 @@ def test_get_past_meeting_details_from_meeting_id_negative(mock_request_get):
         "2020-06-11T06:20:41Z", RFC_3339_DATETIME_FORMAT
     )
     meeting_id = "123123123"
+    dummy_response = {'code': 3001, 'message': 'Meeting does not exist: 123123123.'}
+    dummy_response = json.dumps(dummy_response)
     mock_response = [Mock()]
     mock_response[0].status_code = 400
+    mock_response[0].text = dummy_response
     mock_request_get.side_effect = mock_response
     response = past_meetings_object.get_past_meeting_details_from_meeting_id(
         meeting_id,


### PR DESCRIPTION
The error code 12702 in Zoom API response denotes that we cannot access a meeting a year ago from api endpoint. 
To handle this case we need to return None from `get_past_meeting_details_from_meeting_id()` in this case too along with other errors codes (300 and 200 codes which were already handled in the code).

PFA for possible errors while fetching past meeting details from [Zoom API Documentation](https://marketplace.zoom.us/docs/api-reference/zoom-api/methods/#operation/pastMeetingDetails). 
![image](https://user-images.githubusercontent.com/90465691/171798131-73aac1ac-1816-434e-9a17-1d266f8045c5.png)
