### PR TITLE
Move the loop for counting generated documents above the call for index_documents()

### DIFF
--- a/ees_zoom/sync_enterprise_search.py
+++ b/ees_zoom/sync_enterprise_search.py
@@ -92,12 +92,12 @@ class SyncEnterpriseSearch:
                 for document_list in split_documents_into_equal_chunks(
                     documents_to_index, BATCH_SIZE
                 ):
+                    for document in document_list:
+                        self.generated_documents_ids.add(document["id"])
                     for documents in split_by_max_cumulative_length(
                         document_list, self.max_allowed_bytes
                     ):
                         self.index_documents(documents)
-                    for document in document_list:
-                        self.generated_documents_ids.add(document["id"])
         except Exception as exception:
             self.logger.error(exception)
             self.is_error_ocurred = True


### PR DESCRIPTION
The goal of this PR is to address the following change:
 - Move the counting mechanism for `generated_documents_ids` before calling `index_documents`.

The change was done to avoid following scenario:
 - If the connector encounters an error while calling index_documents(documents), then the count of indexed documents will become greater than the generated documents which is not correct