### PR TITLE
Fix permission-sync command

### DIFF
--- a/ees_zoom/permission_sync_command.py
+++ b/ees_zoom/permission_sync_command.py
@@ -62,13 +62,10 @@ class PermissionSyncCommand(BaseCommand):
                 permission_list = user_permission["results"]
                 for permission in permission_list:
                     self.workplace_search_client.remove_permissions(permission)
-        except ValueError as error:
-            raise error
         except Exception as exception:
             self.logger.exception(
                 f"Error while removing the permissions from the workplace. Error: {exception}"
             )
-            raise exception
 
     def set_permissions_list(self, mappings):
         """Method fetches roles and its members from zoom along with list of permissions associated with each


### PR DESCRIPTION
The goal of this PR is to address the following change:
Fixed a problem in the Permission sync i.e. 
Before the permission sync was mapping the permissions of each enterprise user to the respective zoom user based on the user_mappings.csv file provided. Because of this if there is a change in the permission of the Zoom user, then the user had to run full-sync to ensure that the permission change is reflected in the Enterprise Search for that user. Which is not expected behaviour.

With this PR, we've fixed that problem by adding the implementation logic of mapping the permissions of each enterprise user to all the roles/permissions that that user has in Zoom. Because of this fix, whenever there is an update in the roles/permission for a Zoom user, the user can just run the permission-sync and the same permissions will be reflected in the Enterprise Search