### PR TITLE
Fix for schema accepting empty value in the field 'objects'

### DIFF
--- a/ees_zoom/schema.py
+++ b/ees_zoom/schema.py
@@ -60,7 +60,7 @@ schema = {
     },
     "objects": {
         "type": "dict",
-        "nullable": True,
+        "nullable": False,
         "schema": {
             "users": {
                 "type": "dict",


### PR DESCRIPTION
This PR addresses change related to `schema`:

- Prevent the user from running the connector by passing empty value in the objects fields. 