### PR TITLE
Use only days parameter in place of months for relativedelta function.

### DIFF
--- a/ees_zoom/zoom_chat_messages.py
+++ b/ees_zoom/zoom_chat_messages.py
@@ -15,7 +15,7 @@ from dateutil.relativedelta import relativedelta
 from .constant import CHATS, FILES
 from .utils import constraint_time_range, extract, retry
 
-TIME_CONSTRAINT_FOR_CHATS = (datetime.utcnow()) + relativedelta(months=-6, days=+4)
+TIME_CONSTRAINT_FOR_CHATS = (datetime.utcnow()) + relativedelta(days=-180)
 CHATS_URL = "https://zoom.us/account/archivemsg/search#/list"
 
 


### PR DESCRIPTION
This PR addresses the change related to the `relativedelta` function.

- Simply from `months=-6, days=+4` to `days=-180` as per @artem-shelkovnikov's [comment](https://github.com/elastic/enterprise-search-zoom-connector/pull/34#discussion_r952583640) in #34 